### PR TITLE
Fix navbar dropdown issue

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -20,7 +20,7 @@
         </a>
     </div>
 
-    <div id="navbar-menu" class="navbar-menu is-active">
+    <div id="navbar-menu" class="navbar-menu">
       <div class="navbar-end">
         {{ range $menu }}
         {{ if .HasChildren }}


### PR DESCRIPTION
For debugging purposes I added the `is-active` class to the navbar dropdown menu, which makes the dropdown open upon page load. This is not the desired behavior for a dropdown.