### PR TITLE
Create dedicated links for Flux and Helm Op docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,9 +67,20 @@ sizes = [300,400,600,700]
 type = "sans_serif"
 
 [[menus.main]]
+identifier = "docs"
 name = "Docs"
+
+[[menus.main]]
+name = "Flux"
+parent = "docs"
 url = "https://docs.fluxcd.io"
 weight = 1
+
+[[menus.main]]
+name = "Helm Operator"
+parent = "docs"
+url = "https://docs.fluxcd.io/projects/helm-operator"
+weight = 2
 
 [[menus.main]]
 identifier = "project"


### PR DESCRIPTION
To ease finding the right documentation.

![fluxcd-menu](https://user-images.githubusercontent.com/10063039/63103241-fe037480-bf7c-11e9-92fb-5b1d863fa0cb.png)
![fluxcd-menu-footer](https://user-images.githubusercontent.com/10063039/63103250-0196fb80-bf7d-11e9-9222-312230540c57.png)
