### PR TITLE
Add fluxctl install script for Linux and Darwin

### DIFF
--- a/static/install
+++ b/static/install
@@ -1,0 +1,43 @@
+#! /bin/sh
+
+set -eu
+
+FLUX_VERSION=${FLUX_VERSION:-latest}
+
+if [ ! -x "$(command -v curl)" ]; then
+    echo "curl not found"
+    exit 1
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  filename=fluxctl_darwin_amd64
+else
+  filename=fluxctl_linux_amd64
+fi
+
+tmp=$(mktemp -d /tmp/fluxcd.XXXXXX)
+url="https://github.com/fluxcd/flux/releases/${FLUX_VERSION}/download/${filename}"
+(
+  cd "$tmp"
+  echo "Downloading ${filename}..."
+  curl -LO "${url}"
+  echo ""
+  echo "Download complete!"
+)
+
+(
+  cd "$HOME"
+  mkdir -p ".fluxcd/bin"
+  mv "${tmp}/${filename}" ".fluxcd/bin/fluxctl"
+  chmod +x ".fluxcd/bin/fluxctl"
+)
+
+rm -r "$tmp"
+
+echo ""
+echo "Add fluxctl to your path with:"
+echo ""
+echo "  export PATH=\$PATH:\$HOME/.fluxcd/bin"
+echo ""
+echo "Get started with Flux https://docs.fluxcd.io/en/stable/tutorials/get-started.html"
+echo ""


### PR DESCRIPTION
Preview:

```
curl -sL https://deploy-preview-11--fluxcd.netlify.com/install | sh

Downloading fluxctl_darwin_amd64...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   142    0   142    0     0    348      0 --:--:-- --:--:-- --:--:--   348
100   610    0   610    0     0    965      0 --:--:-- --:--:-- --:--:--   965
100 43.3M  100 43.3M    0     0  8770k      0  0:00:05  0:00:05 --:--:-- 11.5M

Download complete!

Add fluxctl to your path with:

  export PATH=$PATH:$HOME/.fluxcd/bin

Get started with Flux https://docs.fluxcd.io/en/stable/tutorials/get-started.html
```

Similar to:
```
curl -sL https://run.linkerd.io/install | sh
curl -sL https://run.solo.io/gloo/install | sh
curl -sSL https://cli.openfaas.com | sh
```