### PR TITLE
Add MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,9 @@
+The maintainers are generally available in Slack at
+https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
+(obtain an invitation at https://slack.cncf.io/).
+
+In alphabetical order:
+
+Daniel Holbach, Weaveworks <daniel@weave.works> (github: @dholbach, slack: dholbach)
+Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
+Scott Rigby, Weaveworks <scott@weave.works> (github: @scottrigby, slack: scottrigby)


### PR DESCRIPTION
Initial maintainers have formed a "squad" to collaborate on the tasks for the next-gen website.

Once we move into a phase where all documentation is hosted in this repository, it is likely that the list of `MAINTAINERS` will either grow, or that we will start working with an `OWNERS` file.